### PR TITLE
feat: print pipeline notebook diff in CI

### DIFF
--- a/scripts/check-and-format-notebooks.py
+++ b/scripts/check-and-format-notebooks.py
@@ -2,8 +2,8 @@
 
 import argparse
 from copy import deepcopy
-import json
 import difflib
+import json
 from pathlib import Path
 import sys
 from typing import List, Tuple, Union


### PR DESCRIPTION
Show the actual diff in CI if ```scripts/check-and-format-notebooks.py``` fails.