### PR TITLE
refactor: graceful exit if sed is an old version

### DIFF
--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -126,7 +126,6 @@ for i in "${!FILES_TO_CHECK[@]}"; do
         if [ "$(printf '%s\n' "$REQUIRED_VERSION" "$CURRENT_VERSION" | sort -V | head -n1)" != "$REQUIRED_VERSION" ]; then
             echo "sed version must be >= ${REQUIRED_VERSION}" && exit 1
         fi
-
         sed -E -r "s/$RE_SEMVER/$UPDATED_VERSION/" "$FILE_TO_CHANGE" > "$TMPFILE"
         if [ $CHECK == 1 ];
         then

--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -116,6 +116,17 @@ for i in "${!FILES_TO_CHECK[@]}"; do
     else
         # Replace semver in VERSIONFILE with semver obtained from SOURCE_FILE
         TMPFILE=$(mktemp /tmp/new_version.XXXXXX)
+        # Check sed version, exit if version < 4.3
+        if ! sed --version > /dev/null 2>&1; then
+            CURRENT_VERSION=1.archaic
+        else
+            CURRENT_VERSION=$(sed --version | head -n1 | cut -d" " -f4)
+        fi
+        REQUIRED_VERSION="4.3"
+        if [ "$(printf '%s\n' "$REQUIRED_VERSION" "$CURRENT_VERSION" | sort -V | head -n1)" != "$REQUIRED_VERSION" ]; then
+            echo "sed version must be >= ${REQUIRED_VERSION}" && exit 1
+        fi
+
         sed -E -r "s/$RE_SEMVER/$UPDATED_VERSION/" "$FILE_TO_CHANGE" > "$TMPFILE"
         if [ $CHECK == 1 ];
         then


### PR DESCRIPTION
This PR address [this issue](https://github.com/Unstructured-IO/community/issues/41) which asks for a graceful exit in cases where the version of sed is less than 4.3. I have made this version check in my commit and used exit 1 if the check fails. I edited the file inside GitHub itself. Hope it works as expected